### PR TITLE
Fix setup for intellisense (  and maybe others tools)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Dreamcast Environment",
 	// Docker image
 	"image": "maishuji/dc-kos-image:14.2.1-dev-02apr25-kp02apr25-gl01mar25",
+	"postCreateCommand": "source /opt/toolchains/dc/kos/environ.sh",
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -10,7 +11,11 @@
 				"eamodio.gitlens",
 				"github.vscode-github-actions",
 				"shd101wyy.markdown-preview-enhanced"
-			]
+			],
+			"settings": {
+				"terminal.integrated.shell.linux": "/bin/bash",
+				"terminal.integrated.shellArgs.linux": ["--login"]
+			}
 		}
 	},
 	"updateRemoteUserUID": true,

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -14,7 +14,10 @@
             "cStandard": "gnu17",
             "cppStandard": "c++20",
             "configurationProvider": "ms-vscode.cmake-tools",
-            "intelliSenseMode": "linux-gcc-x86"
+            "intelliSenseMode": "gcc-x86",
+            "compileCommands": [
+                "${workspaceFolder}/build/Debug/compile_commands.json"
+            ]
         }
     ],
     "version": 4


### PR DESCRIPTION
# Description

Intellisense was having a lot of issues finding the correct setting for kos compiler.
- It was due to not having proper setup in intellisense context

# Solution
- The solution is first updating the docker image that I rely on to add `source /opt/toolchains/dc/kos/environ.sh` in `/etc/profile`
- Then I ensure that the environment is loaded, so that intellisense can find the proper config from the wrapper_build.

# Following
- Could also solve issues with other toolcs such that `clangd`, `clang-tidy`, ... (not tested)