### PR TITLE
Add `next` button to dialog box

### DIFF
--- a/src/udjourney/include/udjourney/hud/DialogBoxHUD.hpp
+++ b/src/udjourney/include/udjourney/hud/DialogBoxHUD.hpp
@@ -26,12 +26,22 @@ class DialogBoxHUD : public HUDComponent {
     [[nodiscard]] std::string get_type() const override {
         return "DialogBoxHUD";
     }
+    void set_text(const std::string& text);
+    void set_text(std::string&& text);
+
+    [[nodiscard]] const std::vector<std::string>& get_wrapped_lines() const {
+        return m_wrapped_lines;
+    }
+
+    [[nodiscard]] const std::string& get_text() const { return m_text; }
 
     void set_on_finished_callback(std::function<void()> callback);
+    void set_on_next_callback(std::function<void()> callback);
 
  private:
     Rectangle m_rect;
     std::vector<std::string> m_wrapped_lines;
     std::string m_text;
     std::function<void()> m_on_finished_callback = []() {};
+    std::function<void()> m_on_next_callback = []() {};
 };

--- a/src/udjourney/include/udjourney/hud/DialogBoxHUD.hpp
+++ b/src/udjourney/include/udjourney/hud/DialogBoxHUD.hpp
@@ -4,6 +4,7 @@
 #include <raylib/raylib.h>
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -12,11 +13,15 @@
 class DialogBoxHUD : public HUDComponent {
  public:
     explicit DialogBoxHUD(Rectangle iRect);
+    ~DialogBoxHUD() override;
+
     void update(float deltaTime) override;
 
     void handle_input() override {
         // Handle input if needed, e.g., close dialog on key press
         if (IsKeyPressed(KEY_ENTER)) {
+            next_page();
+        } else if (IsKeyPressed(KEY_ESCAPE)) {
             m_on_finished_callback();
         }
     }
@@ -34,6 +39,7 @@ class DialogBoxHUD : public HUDComponent {
     }
 
     [[nodiscard]] const std::string& get_text() const { return m_text; }
+    void next_page();
 
     void set_on_finished_callback(std::function<void()> callback);
     void set_on_next_callback(std::function<void()> callback);
@@ -44,4 +50,6 @@ class DialogBoxHUD : public HUDComponent {
     std::string m_text;
     std::function<void()> m_on_finished_callback = []() {};
     std::function<void()> m_on_next_callback = []() {};
+    struct PImpl;
+    std::unique_ptr<PImpl> m_pimpl;
 };

--- a/src/udjourney/include/udjourney/interfaces/IActor.hpp
+++ b/src/udjourney/include/udjourney/interfaces/IActor.hpp
@@ -16,6 +16,7 @@ enum class ActorState {
 class IActor {
  public:
     explicit IActor(const IGame &game) : m_game(&game) {}
+    virtual ~IActor() = default;
     virtual void draw() const = 0;
     virtual void update(float delta) = 0;
     virtual void process_input() = 0;

--- a/src/udjourney/src/Game.cpp
+++ b/src/udjourney/src/Game.cpp
@@ -185,9 +185,14 @@ void Game::run() {
 
     auto dialog_hud =
         std::make_unique<DialogBoxHUD>(Rectangle{300, 400, 200, 80});
+
     dialog_hud->set_on_finished_callback([this]() {
         m_state = GameState::PLAY;
         m_hud_manager.pop_foreground_hud();
+    });
+
+    dialog_hud->set_on_next_callback([this]() {
+        std::cout << "Next page in dialog box" << std::endl;
     });
 
     m_hud_manager.push_foreground_hud(std::move(dialog_hud));
@@ -231,6 +236,14 @@ void Game::process_input() {
         is_running = false;
     }
 
+
+    if (m_hud_manager.has_focus()) {
+        m_state = GameState::PAUSE;  // Pause the game if HUD has focus
+        // If the HUD has focus, handle input there
+        m_hud_manager.handle_input();
+        return;  // Skip further input processing
+    }
+
     // Pause / Unpause the game
     auto start_pressed = input_mapping.pressed_start();
     if (start_pressed) {
@@ -239,13 +252,6 @@ void Game::process_input() {
         } else {
             m_state = GameState::PLAY;
         }
-    }
-
-    if (m_hud_manager.has_focus()) {
-        m_state = GameState::PAUSE;  // Pause the game if HUD has focus
-        // If the HUD has focus, handle input there
-        m_hud_manager.handle_input();
-        return;  // Skip further input processing
     }
 
     if (m_state == GameState::PLAY) {
@@ -477,7 +483,6 @@ void Game::on_notify(const std::string &iEvent) {
         }
     }  // Split by ';'
 
-    std::cout << "Event: " << str_stream.str() << std::endl;
     switch (mode) {
         case kModeGameOuver: {
             m_state = GameState::GAMEOVER;

--- a/src/udjourney/src/Player.cpp
+++ b/src/udjourney/src/Player.cpp
@@ -53,10 +53,10 @@ struct InputMapping {
         };
         shoot_pressed = []() { return IsMouseButtonDown(MOUSE_LEFT_BUTTON); };
 #else
-        left_pressed = []() { return IsKeyDown(KEY_LEFT); };
-        right_pressed = []() { return IsKeyDown(KEY_RIGHT); };
-        up_pressed = []() { return IsKeyDown(KEY_UP); };
-        down_pressed = []() { return IsKeyDown(KEY_DOWN); };
+        left_pressed = []() { return IsKeyDown(KEY_A); };
+        right_pressed = []() { return IsKeyDown(KEY_D); };
+        up_pressed = []() { return IsKeyDown(KEY_W); };
+        down_pressed = []() { return IsKeyDown(KEY_S); };
         jump_pressed = []() { return IsKeyDown(KEY_SPACE); };
         dash_pressed = []() { return IsKeyDown(KEY_LEFT_SHIFT); };
         shoot_pressed = []() {

--- a/src/udjourney/src/hud/DialogBoxHUD.cpp
+++ b/src/udjourney/src/hud/DialogBoxHUD.cpp
@@ -3,33 +3,32 @@
 
 #include <raylib/raylib.h>
 
+#include <functional>
 #include <sstream>
 #include <string>
 #include <utility>
-#include <functional>
 
-DialogBoxHUD::DialogBoxHUD(Rectangle iRect) : m_rect(iRect) {
-    // Initialize the dialog box with a default message
-    m_text = "Hello, this is a dialog box!";
-    m_is_focusable = true;  // Set focusable to true
-}
+namespace internal {
 
-void DialogBoxHUD::update(float deltaTime) {
-    const int font_size = 20;
-    const int padding = 10;
-    float max_width = m_rect.width - 2 * padding;
+struct TextOptions {
+    int font_size;
+    int max_width;
+    int padding;
+} text_options;
 
-    m_wrapped_lines.clear();
-    std::istringstream stream(m_text);
+void wrap_text(const std::string& iText, TextOptions iTextOptions,
+               std::vector<std::string>& oWrappedLines) {
+    oWrappedLines.clear();
+    std::istringstream stream(iText);
     std::string word;
     std::string line;
 
     while (stream >> word) {
         std::string test_line = line.empty() ? word : line + " " + word;
-        int line_width = MeasureText(test_line.c_str(), font_size);
+        int line_width = MeasureText(test_line.c_str(), iTextOptions.font_size);
 
-        if (line_width > static_cast<int>(max_width)) {
-            m_wrapped_lines.push_back(line);
+        if (line_width > static_cast<int>(iTextOptions.max_width)) {
+            oWrappedLines.push_back(line);
             line = word;
         } else {
             line = test_line;
@@ -37,8 +36,33 @@ void DialogBoxHUD::update(float deltaTime) {
     }
 
     if (!line.empty()) {
-        m_wrapped_lines.push_back(line);
+        oWrappedLines.push_back(line);
     }
+}
+}  // namespace internal
+
+DialogBoxHUD::DialogBoxHUD(Rectangle iRect) : m_rect(iRect) {
+    // Initialize the dialog box with a default message
+    m_text = "Hello, this is a dialog box!";
+    m_is_focusable = true;  // Set focusable to true
+    internal::text_options.font_size = 20;
+    internal::text_options.padding = 10;
+    internal::text_options.max_width =
+        static_cast<int>(m_rect.width - 2 * internal::text_options.padding);
+    internal::wrap_text(m_text, internal::text_options, m_wrapped_lines);
+}
+
+void DialogBoxHUD::set_text(const std::string& text) {
+    m_text = text;
+    internal::wrap_text(m_text, internal::text_options, m_wrapped_lines);
+}
+void DialogBoxHUD::set_text(std::string&& text) {
+    m_text = std::move(text);
+    internal::wrap_text(m_text, internal::text_options, m_wrapped_lines);
+}
+
+void DialogBoxHUD::update(float deltaTime) {
+    // To implement
 }
 
 void DialogBoxHUD::draw() const {
@@ -59,7 +83,10 @@ void DialogBoxHUD::draw() const {
     }
 }
 
-void DialogBoxHUD::set_on_finished_callback(
-    std::function<void()> callback) {
+void DialogBoxHUD::set_on_finished_callback(std::function<void()> callback) {
     m_on_finished_callback = std::move(callback);
+}
+
+void DialogBoxHUD::set_on_next_callback(std::function<void()> callback) {
+    m_on_next_callback = std::move(callback);
 }

--- a/src/udjourney/src/hud/DialogBoxHUD.cpp
+++ b/src/udjourney/src/hud/DialogBoxHUD.cpp
@@ -3,10 +3,13 @@
 
 #include <raylib/raylib.h>
 
+#include <algorithm>
 #include <functional>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace internal {
 
@@ -14,7 +17,7 @@ struct TextOptions {
     int font_size;
     int max_width;
     int padding;
-} text_options;
+};
 
 void wrap_text(const std::string& iText, TextOptions iTextOptions,
                std::vector<std::string>& oWrappedLines) {
@@ -41,24 +44,67 @@ void wrap_text(const std::string& iText, TextOptions iTextOptions,
 }
 }  // namespace internal
 
-DialogBoxHUD::DialogBoxHUD(Rectangle iRect) : m_rect(iRect) {
+struct DialogBoxHUD::PImpl {
+    internal::TextOptions text_options;  // Text options for wrapping
+    Rectangle button_rect;
+    size_t page_cnt = 0;
+    size_t current_page = 0;
+    int_fast8_t line_per_page = 3;
+};
+
+size_t compute_page_count(size_t wrapped_lines_count, size_t lines_per_page) {
+    if (lines_per_page == 0) {
+        return 0;  // Avoid division by zero
+    }
+    return (wrapped_lines_count + lines_per_page - 1) / lines_per_page;
+}
+
+DialogBoxHUD::DialogBoxHUD(Rectangle iRect) :
+    m_rect(iRect), m_pimpl(std::make_unique<DialogBoxHUD::PImpl>()) {
     // Initialize the dialog box with a default message
-    m_text = "Hello, this is a dialog box!";
+    m_text =
+        "Hello, this is a dialog box!\n Testing severallinesof texts "
+        "to see how it wraps and displays.\nPress Enter to continue or "
+        "Escape to close.";
     m_is_focusable = true;  // Set focusable to true
-    internal::text_options.font_size = 20;
-    internal::text_options.padding = 10;
-    internal::text_options.max_width =
-        static_cast<int>(m_rect.width - 2 * internal::text_options.padding);
-    internal::wrap_text(m_text, internal::text_options, m_wrapped_lines);
+    m_pimpl->text_options.font_size = 20;
+    m_pimpl->text_options.padding = 10;
+    m_pimpl->text_options.max_width =
+        static_cast<int>(m_rect.width) -
+        2 * static_cast<int>(m_pimpl->text_options.padding);
+    internal::wrap_text(m_text, m_pimpl->text_options, m_wrapped_lines);
+    m_pimpl->page_cnt =
+        compute_page_count(m_wrapped_lines.size(), m_pimpl->line_per_page);
+
+    m_pimpl->button_rect = Rectangle{
+        m_rect.x + m_rect.width - 40,
+        m_rect.y + m_rect.height - 40,
+        30,
+        30};  // Position the button at the bottom right of the dialog box
+}
+
+DialogBoxHUD::~DialogBoxHUD() = default;
+
+void DialogBoxHUD::next_page() {
+    if (m_pimpl->current_page < m_pimpl->page_cnt - 1) {
+        m_pimpl->current_page++;
+        m_on_next_callback();  // Add custom behavior for next page
+    } else {
+        m_on_finished_callback();
+    }
 }
 
 void DialogBoxHUD::set_text(const std::string& text) {
     m_text = text;
-    internal::wrap_text(m_text, internal::text_options, m_wrapped_lines);
+    internal::wrap_text(m_text, m_pimpl->text_options, m_wrapped_lines);
+    m_pimpl->page_cnt =
+        compute_page_count(m_wrapped_lines.size(), m_pimpl->line_per_page);
 }
 void DialogBoxHUD::set_text(std::string&& text) {
     m_text = std::move(text);
-    internal::wrap_text(m_text, internal::text_options, m_wrapped_lines);
+    internal::wrap_text(m_text, m_pimpl->text_options, m_wrapped_lines);
+    m_pimpl->page_cnt =
+        compute_page_count(m_wrapped_lines.size(), m_pimpl->line_per_page);
 }
 
 void DialogBoxHUD::update(float deltaTime) {
@@ -73,14 +119,24 @@ void DialogBoxHUD::draw() const {
     DrawRectangleRec(m_rect, DARKGRAY);
 
     float pos_y = m_rect.y + padding;
-    for (const std::string& line : m_wrapped_lines) {
+
+    auto start_index = m_pimpl->current_page * m_pimpl->line_per_page;
+    auto end_index =
+        std::min(start_index + m_pimpl->line_per_page, m_wrapped_lines.size());
+    for (size_t i = start_index; i < end_index; ++i) {
+        if (i >= m_wrapped_lines.size()) {
+            break;  // Prevent out-of-bounds access
+        }
+        const std::string& line = m_wrapped_lines[i];
         DrawText(line.c_str(),
                  static_cast<int>(m_rect.x + padding),
                  static_cast<int>(pos_y),
                  fontSize,
                  WHITE);
-        pos_y += fontSize + 4;
+        pos_y += fontSize + 4;  // Add some spacing between lines
     }
+
+    DrawRectangleRec(m_pimpl->button_rect, LIGHTGRAY);
 }
 
 void DialogBoxHUD::set_on_finished_callback(std::function<void()> callback) {

--- a/src/udjourney/src/platform/behavior_strategies/OscillatingSizeBehaviorStrategy.cpp
+++ b/src/udjourney/src/platform/behavior_strategies/OscillatingSizeBehaviorStrategy.cpp
@@ -63,18 +63,13 @@ void OscillatingSizeBehaviorStrategy::update(Platform &ioPlatform,
             m_pimpl->max_offset =
                 (kMaxSizeAcceptable - m_pimpl->original_width) / 2.0F;
         }
-        //std::cout << "min_offset " << m_pimpl->min_offset
-        //          << " , max_offset: " << m_pimpl->max_offset << std::endl;
     }
 
     // Compute bounds
     const float max_width = m_pimpl->original_width + m_pimpl->max_offset;
     const float min_width = m_pimpl->original_width + m_pimpl->min_offset;
 
-    //std::cout << "min_width " << min_width << " , max_width: " << max_width
-    //          << " , speed_x: " << m_pimpl->factor << std::endl;
-    //std::cout << "\t rect_width = " << rect.width << std::endl;
-    // If bounds are hit, reverse direction
+    //  If bounds are hit, reverse direction
     if (rect.width >= max_width) {
         m_pimpl->factor = -1.0F;  // Start shrinking
     } else if (rect.width <= min_width) {


### PR DESCRIPTION
In this PR:
- Add next button to the dialog box
- Process dialog box to separate content into pages
- Add callback to listen to next event